### PR TITLE
aphlict does not startup

### DIFF
--- a/40-aphlict
+++ b/40-aphlict
@@ -44,6 +44,9 @@ EOF
 
   # Aphlict needs write access to this directory
   chmod a+rwX /run/watch
+  # Aphlict needs write access / ownership to pid directory
+  mkdir -p /var/tmp/aphlict/pid
+  chown 2000:2000 /var/tmp/aphlict/pid
 fi
 
 if [ ! -f /is-baking ]; then


### PR DESCRIPTION
Aphlict is not able to write its own pid-file, because the target directory is owned by root.