### PR TITLE
hostkeys persisting bug

### DIFF
--- a/BASIC-CONFIG.md
+++ b/BASIC-CONFIG.md
@@ -65,7 +65,7 @@ To provide SSH access to repositories, you need to set a path to store the SSH h
 
 ```
 docker run ... \
-    --env PHABRICATOR_HOST_KEYS_PATH=/hostkeys \
+    --env PHABRICATOR_HOST_KEYS_PATH=/hostkeys/persisted \
     -v /path/on/host:/hostkeys \
     ...
 ```


### PR DESCRIPTION
45-phabicator-ssh tests if hostkey directory exists and if it does tries to copy existing files into container setup ssh keys location.
and if it doesn't exist - creates keys and then copies it into the persisting folder.

the problem is that in original declaration the folder always exists, so the script doesn't go to the generation branch of the if/else.
declaring path as a subdirectory of a mapped directory solves this.