### PR TITLE
Fix 'Configuration' links in README for Docker Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ docker run \
 
 ## Configuration
 
-For basic configuration in getting the image running, refer to [Basic Configuration](BASIC-CONFIG.md).
+For basic configuration in getting the image running, refer to [Basic Configuration](https://github.com/hach-que-docker/phabricator/blob/master/BASIC-CONFIG.md).
 
 For more advanced configuration topics including:
 
@@ -28,7 +28,7 @@ For more advanced configuration topics including:
 * Running custom commands during the boot process, and
 * Baking configuration into your own derived Docker image
 
-refer to [Advanced Configuration](ADVANCED-CONFIG.md).
+refer to [Advanced Configuration](https://github.com/hach-que-docker/phabricator/blob/master/ADVANCED-CONFIG.md).
 
 For users that are upgrading to this version and currently using the old `/config` mechanism to configure Phabricator, this configuration mechanism will continue to work, but it's recommended that you migrate to environment variables or baked images when you next get the chance.
 


### PR DESCRIPTION
The README.md file for this project automatically becomes a [web page on Docker Hub](https://hub.docker.com/r/hachque/phabricator/) after a build.
 
The links for "Basic Configuration" and "Advanced Configuration" in README.md do not work properly on this generated page.  For example it points to this URL, which 404s:  https://hub.docker.com/r/hachque/phabricator/ADVANCED-CONFIG.md/

This changes the links to point to their GitHub blobs on master.  The other Markdown files don't require this because they do not appear on Docker Hub.