### PR TITLE
fix git ssh freeze during connection

### DIFF
--- a/sshd_config.phabricator
+++ b/sshd_config.phabricator
@@ -18,6 +18,7 @@ PrintMotd no
 PrintLastLog no
 PasswordAuthentication no
 AuthorizedKeysFile none
+UseDNS no
 
 PidFile /run/sshd-phabricator.pid
 


### PR DESCRIPTION
The sshd does a reverse dns lookup for the connecting client. In most cases this rdns entry does not exist and the connection frezzes, due to the dns timeout. The solution is to disable the DNS lookup for the sshd.