### PR TITLE
restart aphlict, ensuring clean container restart

### DIFF
--- a/preflight/run-aphlict.sh
+++ b/preflight/run-aphlict.sh
@@ -52,7 +52,7 @@ fi
 if [ ! -f /is-baking ]; then
   # Start the Phabricator notification server
   pushd /srv/phabricator/phabricator
-  sudo -u "$PHABRICATOR_VCS_USER" bin/aphlict start --config=/srv/aphlict.conf
+  sudo -u "$PHABRICATOR_VCS_USER" bin/aphlict restart --config=/srv/aphlict.conf
   popd
 
   set +e


### PR DESCRIPTION
When i restart my container supervisord tries to start aphlict with '[...] bin/aphlict start [...]' which produces the following output: 

> Reading configuration from: /srv/aphlict.conf
> Usage Exception: Unable to start notifications server because it is already running. Use `aphlict restart` to restart it.
> 2017-05-30 15:07:11,412 INFO exited: aphlict (exit status 77; not expected)
> 2017-05-30 15:07:28,436 INFO spawned: 'aphlict' with pid 1034

The supervisord aphlict process returns immediately, because it notes that aphlict is already running and it tries endlessly to start it. This is solved by using the restart statement instead of the start statement, which stops previously running aphlict and ensures that supervisord correctly determines a running aphlict.