### PR TITLE
Added support for AWS S3 region and endpoint config

### DIFF
--- a/ENV-LIST.md
+++ b/ENV-LIST.md
@@ -11,6 +11,8 @@
 - `PHABRICATOR_HOST_KEYS_PATH` - The path to store SSH host keys in.  This directory should be a volume mapped from the host, otherwise clients will be unable to connect after the container is restarted.
 - `AWS_S3_ACCESS_KEY` - The AWS access key to use for S3.  Only needed when the `s3` storage type is selected.
 - `AWS_S3_SECRET_KEY` - The AWS secret key to use for S3.  Only needed when the `s3` storage type is selected.
+- `AWS_S3_REGION` - The AWS region to use for S3.  Only needed when the `s3` storage type is selected. Used in combination with `AWS_S3_REGION`. See [AWS Docs](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region).
+- `AWS_S3_ENDPOINT` - The AWS endpoint to use for S3.  Only needed when the `s3` storage type is selected. Used in combination with `AWS_S3_ENDPOINT`. See [AWS Docs](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region).
 - `MYSQL_HOST` - Use this if you want to connect to an external MySQL host (see [Basic Configuration](BASIC-CONFIG.md)).
 - `MYSQL_PORT` - When connecting to an external MySQL host, use this port (optional).
 - `MYSQL_USER` - The user to connect to MySQL as.

--- a/preflight/10-boot-conf
+++ b/preflight/10-boot-conf
@@ -239,6 +239,12 @@ fi
 if [ "$AWS_S3_SECRET_KEY" != "" ]; then
   sudo -u "$PHABRICATOR_VCS_USER" ./bin/config set amazon-s3.secret-key "$AWS_S3_SECRET_KEY"
 fi
+if [ "$AWS_S3_REGION" != "" ]; then
+  sudo -u "$PHABRICATOR_VCS_USER" ./bin/config set amazon-s3.region "$AWS_S3_REGION"
+fi
+if [ "$AWS_S3_ENDPOINT" != "" ]; then
+  sudo -u "$PHABRICATOR_VCS_USER" ./bin/config set amazon-s3.endpoint "$AWS_S3_ENDPOINT"
+fi
 if [ "$SSL_TYPE" == "none" ]; then
   APHLICT_PROTOCOL="http"
   APHLICT_PORT=80


### PR DESCRIPTION
Phabricator raises a setup issue for S3 configuration asking for `amazon-s3.region` and `amazon-s3.endpoint` for S3-based storage to work.

Added new environment variables `AWS_S3_REGION` and `AWS_S3_ENDPOINT` that would update phabricator configuration.